### PR TITLE
Inventory Script Not Always Cleaning Up

### DIFF
--- a/src/Integration.ps1
+++ b/src/Integration.ps1
@@ -157,6 +157,9 @@ $Integration | Add-DynamicIntegrationCapability -Interface ISupportsInventoryIde
             $Reader.Close()
             $Stream.Close()
 
+            # Remove copy of config to cleanup
+            Remove-Item -Path "$($env:TEMP)\aristos.cfg" -Force
+
             # Parse INI-style config to locate GUID under the [Config] section
             $CurrentSection = ""
             $InTargetSection = $false
@@ -187,15 +190,10 @@ $Integration | Add-DynamicIntegrationCapability -Interface ISupportsInventoryIde
                     }
                 }
             }
-
-            # Remove copy of config to cleanup
-            Remove-Item -Path "$($env:TEMP)\aristos.cfg" -Force
         } else {
             return $null
         }
     }
-
-    return $null
 }
 
 # ---- ISupportsTenantInstallToken: retrieves a D2C agent install token ----


### PR DESCRIPTION
Moved removal of aristos.cfg copy to happen earlier in script to ensure deletion. Removed unneeded return at the end of the same section.
Fixes #5